### PR TITLE
fix #41 filter on extensions do not work anymore

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -139,7 +139,7 @@ module.exports = class Router extends express.Router {
       this.unifile.readdir(req.session.unifile, req.params[0], req.params[1])
       .then((result) => {
         // Allows '' to filter only the folders
-        if (req.query.extensions instanceof String) {
+        if (req.query.extensions) {
           const extensions = req.query.extensions.split(',');
           res.send(result.filter((file) => file.isDir || extensions.includes(Path.extname(file.name).toLowerCase())));
         } else {


### PR DESCRIPTION
this was due to instanceof String returning false in the case of req.query.*
cc @JbIPS 