### PR TITLE
Reactivate WebDAV connector

### DIFF
--- a/dist/login/webdav_login.html
+++ b/dist/login/webdav_login.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div>
-      <form action="/webdav/oauth-callback" method="get" accept-charset="utf-8">
+      <form action="/webdav/oauth_callback" method="get" accept-charset="utf-8">
         <h1>Unifile would like access to your files and folders.</h1>
         <div>
           <label for="host">host</label>

--- a/lib/router.js
+++ b/lib/router.js
@@ -10,6 +10,7 @@ const express = require('express');
 const Path = require('path');
 const {PassThrough} = require('stream');
 const Unifile = require('unifile');
+const WebDavConnector = require('unifile-webdav');
 
 // File upload
 const multer = require('multer');
@@ -79,7 +80,9 @@ module.exports = class Router extends express.Router {
     if (options.ftp) {
       this.unifile.use(new Unifile.FtpConnector(options.ftp));
     }
-    // If(options.webdav) this.unifile.use(new Unifile.WebDavConnector(options.webdav));
+    if (options.webdav) {
+      this.unifile.use(new WebDavConnector(options.webdav));
+    }
     if (options.fs) {
       this.unifile.use(new Unifile.FsConnector(options.fs));
     }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "browserify": "^13.0.1",
     "connect-multiparty": "^2.0.0",
     "cookie-parser": "^1.4.3",
-    "express": "^4.0.0",
+    "express": "^4.16.0",
     "express-session": "^1.13.0",
     "font-awesome": "^4.6.3",
     "multer": "^1.3.0",
@@ -43,7 +43,8 @@
     "react": "^15.2.0",
     "react-dom": "^15.2.0",
     "request": "^2.72.0",
-    "unifile": "silexlabs/unifile#master"
+    "unifile": "^2.0.2",
+    "unifile-webdav": "^1.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.2",


### PR DESCRIPTION
Closes #56 

Although Silex should deactivate its WebDAV conf (in environment) if it doesn't want to support WebDAV (for native bindings reasons)