### PR TITLE
Use POST for non-OAuth login

### DIFF
--- a/dist/login/ftp_login.html
+++ b/dist/login/ftp_login.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div>
-      <form action="/ftp/oauth_callback" method="get" accept-charset="utf-8">
+      <form action="/ftp/login_callback" method="post" accept-charset="utf-8">
         <h1>Unifile would like access to your files and folders.</h1>
         <div>
           <label for="host">host</label>

--- a/dist/login/sftp_login.html
+++ b/dist/login/sftp_login.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div>
-      <form action="/sftp/oauth-callback" method="get" accept-charset="utf-8">
+      <form action="/sftp/login_callback" method="post" accept-charset="utf-8">
         <h1>Unifile would like access to your files and folders.</h1>
         <div>
           <label for="host">host</label>

--- a/lib/router.js
+++ b/lib/router.js
@@ -287,6 +287,18 @@ module.exports = class Router extends express.Router {
       }
     });
 
+    // Register callback url
+    this.post('/:connector/login_callback', express.urlencoded(), (req, res) => {
+      this.unifile.login(req.session.unifile, req.params.connector, req.body)
+      .then((result) => {
+        res.cookie(`unifile_${req.params.connector}`, result);
+        res.end('<script>window.close();</script>');
+      })
+      .catch((err) => {
+        res.status(SYSTEM_ERROR_STATUS).send(err);
+      });
+    });
+
     this.get('/remotestorage/callback', (req, res) => {
       // Return a script that get the hash and redirect to oauth-callback
       res.end('<script>' +


### PR DESCRIPTION
Login forms now use a POST route

Closes #59 
Closes #35 