### PR TITLE
Remove content decoding in upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const port = process.env.PORT || DEFAULT_PORT;
 const rootUrl = process.env.SERVER_URL || `http://localhost:${port}`;
 
 const app = express();
+app.use(express.json());
 app.use(cookieParser());
 app.use(session({
   resave: false,

--- a/lib/router.js
+++ b/lib/router.js
@@ -109,6 +109,10 @@ module.exports = class Router extends express.Router {
       });
       req.next();
     });
+
+    // Enable body parsing for all routes
+    this.use(express.json());
+
     // List services
     this.get('/services', (req, res) => {
       const services = [];
@@ -248,7 +252,7 @@ module.exports = class Router extends express.Router {
         );
       } else {
         const actions = req.files.map((file) => ({
-          content: file.buffer.toString(),
+          content: file.buffer,
           name: 'writeFile',
           path: Path.join(req.params[1], file.originalname)
         }));

--- a/lib/router.js
+++ b/lib/router.js
@@ -110,9 +110,6 @@ module.exports = class Router extends express.Router {
       req.next();
     });
 
-    // Enable body parsing for all routes
-    this.use(express.json());
-
     // List services
     this.get('/services', (req, res) => {
       const services = [];
@@ -187,6 +184,7 @@ module.exports = class Router extends express.Router {
     });
 
     this.patch(/\/(.*)\/mv\/(.*)/, (req, res) => {
+      if (!req.body) Router.handleError(res, new Error('No body parsed supplied'));
       this.unifile.rename(req.session.unifile, req.params[0], req.params[1], req.body.destination)
       .then(() => {
         res.status(EMPTY_STATUS).send();
@@ -195,6 +193,7 @@ module.exports = class Router extends express.Router {
     });
 
     this.delete(/\/(.*)\/rm\//, (req, res) => {
+      if (!req.body) Router.handleError(res, new Error('No body parsed supplied'));
       let rmPromised = null;
       if (req.body.length === 1) {
         const [action] = req.body.filter((a) => [
@@ -225,6 +224,7 @@ module.exports = class Router extends express.Router {
     });
 
     this.post(/\/(.*)\/cp\/(.*)/, (req, res) => {
+      if (!req.body) Router.handleError(res, new Error('No body parsed supplied'));
       let stream = this.unifile.createReadStream(req.session.unifile, req.params[0], req.params[1]);
       // Use PassThrough to prevent request from copying headers between requests
       if (req.params[0] !== 'webdav' && req.params[0] !== 'fs') {
@@ -235,6 +235,7 @@ module.exports = class Router extends express.Router {
     });
 
     this.post(/\/(.*)\/upload\/(.*)/, upload.array('content'), (req, res) => {
+      if (!req.body) Router.handleError(res, new Error('No body parsed supplied'));
       let batchPromised = null;
       if (req.files.length === 0) {
         batchPromised = this.unifile.writeFile(
@@ -294,6 +295,7 @@ module.exports = class Router extends express.Router {
 
     // Register callback url
     this.post('/:connector/login_callback', express.urlencoded(), (req, res) => {
+      if (!req.body) Router.handleError(res, new Error('No body parsed supplied'));
       this.unifile.login(req.session.unifile, req.params.connector, req.body)
       .then((result) => {
         res.cookie(`unifile_${req.params.connector}`, result);


### PR DESCRIPTION
When uploading a bunch of file, do not decode content and let Unifile handle the Buffer.

Also add bodyParser for all route (rm, cp, mv were broken).

Closes #64 